### PR TITLE
add move events to nft booster and create direct contributor custom vault

### DIFF
--- a/src/custom-vaults/examples/direct-contributor/DirectContributor.sol
+++ b/src/custom-vaults/examples/direct-contributor/DirectContributor.sol
@@ -28,7 +28,7 @@ contract DirectContributor is TwabERC20, Claimable, Ownable2Step {
         address owner_,
         address[] memory initialMintRecipients_,
         uint256[] memory initialMintAmounts_
-    ) Claimable(prizePool_, claimer_) TwabERC20(shareName_, shareSymbol_, prizePool.twabController()) Ownable() {
+    ) Claimable(prizePool_, claimer_) TwabERC20(shareName_, shareSymbol_, prizePool_.twabController()) Ownable() {
         _transferOwnership(owner_);
         assert(initialMintRecipients_.length == initialMintAmounts_.length);
         for (uint256 i = 0; i < initialMintRecipients_.length; i++) {

--- a/src/custom-vaults/examples/direct-contributor/DirectContributor.sol
+++ b/src/custom-vaults/examples/direct-contributor/DirectContributor.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { Ownable2Step, Ownable } from "openzeppelin/access/Ownable2Step.sol";
+import { Claimable } from "pt-v5-vault/abstract/Claimable.sol";
+import { PrizePool } from "pt-v5-prize-pool/PrizePool.sol";
+import { TwabERC20 } from "pt-v5-vault/TwabERC20.sol";
+
+/// @title PoolTogether V5 - DirectContributor
+/// @notice A contract that simulates prize vault behaviour, but with direct contributions only.
+/// @dev The owner of this contract can mint new shares and change the permitted claimer.
+/// @author G9 Software Inc.
+contract DirectContributor is TwabERC20, Claimable, Ownable2Step {
+
+    /// @notice Constructs a new GP Boost Hook
+    /// @param shareName_ The share token name
+    /// @param shareSymbol_ The share token symbol
+    /// @param prizePool_ The prize pool to participate in
+    /// @param claimer_ The permitted claimer for prizes
+    /// @param owner_ The owner of the direct contributor contract
+    /// @param initialMintRecipients_ The recipients for the initial share mint
+    /// @param initialMintAmounts_ The amount to mint to each respective recipient
+    constructor(
+        string memory shareName_,
+        string memory shareSymbol_,
+        PrizePool prizePool_,
+        address claimer_,
+        address owner_,
+        address[] memory initialMintRecipients_,
+        uint256[] memory initialMintAmounts_
+    ) Claimable(prizePool_, claimer_) TwabERC20(shareName_, shareSymbol_, prizePool.twabController()) Ownable() {
+        _transferOwnership(owner_);
+        assert(initialMintRecipients_.length == initialMintAmounts_.length);
+        for (uint256 i = 0; i < initialMintRecipients_.length; i++) {
+            _mint(initialMintRecipients_[i], initialMintAmounts_[i]);
+        }
+    }
+
+    /// @notice Allows the owner to mint more shares
+    function mint(address _to, uint256 _shares) external onlyOwner {
+        _mint(_to, _shares);
+    }
+
+    /// @notice Allows the owner to set a new claimer
+    function setClaimer(address _claimer) external onlyOwner {
+        _setClaimer(_claimer);
+    }
+    
+}

--- a/src/custom-vaults/examples/direct-contributor/DirectContributor.sol
+++ b/src/custom-vaults/examples/direct-contributor/DirectContributor.sol
@@ -12,7 +12,7 @@ import { TwabERC20 } from "pt-v5-vault/TwabERC20.sol";
 /// @author G9 Software Inc.
 contract DirectContributor is TwabERC20, Claimable, Ownable2Step {
 
-    /// @notice Constructs a new GP Boost Hook
+    /// @notice Constructor
     /// @param shareName_ The share token name
     /// @param shareSymbol_ The share token symbol
     /// @param prizePool_ The prize pool to participate in

--- a/src/prize-hooks/examples/nft-chance-booster/NftChanceBoosterHook.sol
+++ b/src/prize-hooks/examples/nft-chance-booster/NftChanceBoosterHook.sol
@@ -94,7 +94,7 @@ contract NftChanceBoosterHook is IPrizeHooks {
     /// used to provide variance in the entropy for each prize so there can be multiple winners per draw.
     /// @dev Tries to select a winner until the call runs out of gas before reverting to the backup action of 
     /// contributing the prize on behalf of the boosted vault.
-    function beforeClaimPrize(address, uint8 _tier, uint32 _prizeIndex, uint96, address) external view returns (address, bytes memory) {
+    function beforeClaimPrize(address _winner, uint8 _tier, uint32 _prizeIndex, uint96, address) external view returns (address, bytes memory) {
         uint256 _tierStartTime;
         uint256 _tierEndTime;
         uint256 _winningRandomNumber = prizePool.getWinningRandomNumber();
@@ -117,7 +117,7 @@ contract NftChanceBoosterHook is IPrizeHooks {
                     _randomTokenId = tokenIdLowerBound;
                 } else {
                     _randomTokenId = tokenIdLowerBound + UniformRandomNumber.uniform(
-                        uint256(keccak256(abi.encode(_winningRandomNumber, _tier, _prizeIndex, _pickAttempt))),
+                        uint256(keccak256(abi.encode(_winningRandomNumber, _winner, _tier, _prizeIndex, _pickAttempt))),
                         _numTokens
                     );
                 }


### PR DESCRIPTION
- NFT booster now emits more data in events (how many times it tried to select a winner, who won what prize)
- New direct contributor custom vault that makes it easy to spin up no-deposit prize tokens (can be used in conjunction with the NFT booster to artificially boost NFT win chance with minimal setup)